### PR TITLE
feat: Make response envelope generic

### DIFF
--- a/pkg/middleware/request_tracer_test.go
+++ b/pkg/middleware/request_tracer_test.go
@@ -1,8 +1,6 @@
 package middleware
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/labstack/echo/v5"
@@ -49,8 +47,4 @@ func createCallableTracerHandler() (echo.HandlerFunc, *bool, *echo.Context) {
 	middleware, called, ctx := createCallableHandler(generator)
 
 	return middleware, called, ctx
-}
-
-func generateTestEchoContextFromRequestForTracer(req *http.Request) (*echo.Context, *httptest.ResponseRecorder) {
-	return generateTestEchoContextFromRequest(req)
 }

--- a/pkg/middleware/response_envelope.go
+++ b/pkg/middleware/response_envelope.go
@@ -17,7 +17,7 @@ func ResponseEnvelope() echo.MiddlewareFunc {
 		RequestIDHandler: func(c *echo.Context, requestId string) {
 			echoResp, err := echo.UnwrapResponse(c.Response())
 			if err == nil {
-				rw := rest.NewResponseEnvelopeWriter[any](echoResp.ResponseWriter, requestId, rest.DecodeJSONOrString)
+				rw := rest.NewResponseEnvelopeWriter(echoResp.ResponseWriter, requestId, rest.DecodeJSONOrString)
 				echoResp.ResponseWriter = rw
 			}
 		},

--- a/pkg/middleware/response_envelope.go
+++ b/pkg/middleware/response_envelope.go
@@ -9,7 +9,7 @@ import (
 
 const requestIdHeader = "X-Request-Id"
 
-func ResponseEnvelope[T any]() echo.MiddlewareFunc {
+func ResponseEnvelope() echo.MiddlewareFunc {
 	config := middleware.RequestIDConfig{
 		Generator: func() string {
 			return uuid.New().String()
@@ -17,7 +17,7 @@ func ResponseEnvelope[T any]() echo.MiddlewareFunc {
 		RequestIDHandler: func(c *echo.Context, requestId string) {
 			echoResp, err := echo.UnwrapResponse(c.Response())
 			if err == nil {
-				rw := rest.NewResponseEnvelopeWriter[T](echoResp.ResponseWriter, requestId)
+				rw := rest.NewResponseEnvelopeWriter[any](echoResp.ResponseWriter, requestId, rest.DecodeJSONOrString)
 				echoResp.ResponseWriter = rw
 			}
 		},

--- a/pkg/middleware/response_envelope.go
+++ b/pkg/middleware/response_envelope.go
@@ -9,7 +9,7 @@ import (
 
 const requestIdHeader = "X-Request-Id"
 
-func ResponseEnvelope() echo.MiddlewareFunc {
+func ResponseEnvelope[T any]() echo.MiddlewareFunc {
 	config := middleware.RequestIDConfig{
 		Generator: func() string {
 			return uuid.New().String()
@@ -17,7 +17,7 @@ func ResponseEnvelope() echo.MiddlewareFunc {
 		RequestIDHandler: func(c *echo.Context, requestId string) {
 			echoResp, err := echo.UnwrapResponse(c.Response())
 			if err == nil {
-				rw := rest.NewResponseEnvelopeWriter(echoResp.ResponseWriter, requestId)
+				rw := rest.NewResponseEnvelopeWriter[T](echoResp.ResponseWriter, requestId)
 				echoResp.ResponseWriter = rw
 			}
 		},

--- a/pkg/rest/decoder.go
+++ b/pkg/rest/decoder.go
@@ -1,0 +1,31 @@
+package rest
+
+import "encoding/json"
+
+func DecodeJSONTo[T any](data []byte) (T, error) {
+	var out T
+	err := json.Unmarshal(data, &out)
+	if err != nil {
+		return out, err
+	}
+
+	return out, nil
+}
+
+func DecodeRawBytes(data []byte) ([]byte, error) {
+	return data, nil
+}
+
+func DecodeString(data []byte) (string, error) {
+	return string(data), nil
+}
+
+func DecodeJSONOrString(data []byte) (any, error) {
+	var out any
+	err := json.Unmarshal(data, &out)
+	if err == nil {
+		return out, nil
+	}
+
+	return string(data), nil
+}

--- a/pkg/rest/decoder_test.go
+++ b/pkg/rest/decoder_test.go
@@ -1,0 +1,58 @@
+package rest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type decoderDetails struct {
+	Value int `json:"value"`
+}
+
+func TestUnit_Decoder_DecodeJSONTo_Succeeds(t *testing.T) {
+	actual, err := DecodeJSONTo[decoderDetails]([]byte(`{"value":12}`))
+	require.Nil(t, err)
+
+	expected := decoderDetails{Value: 12}
+	assert.Equal(t, expected, actual)
+}
+
+func TestUnit_Decoder_DecodeJSONTo_FailsOnInvalidJSON(t *testing.T) {
+	_, err := DecodeJSONTo[decoderDetails]([]byte(`{"value":`))
+	require.Error(t, err)
+}
+
+func TestUnit_Decoder_DecodeRawBytes_ReturnsInput(t *testing.T) {
+	actual, err := DecodeRawBytes([]byte("some-data"))
+	require.Nil(t, err)
+
+	assert.Equal(t, []byte("some-data"), actual)
+}
+
+func TestUnit_Decoder_DecodeString_ReturnsInputAsString(t *testing.T) {
+	actual, err := DecodeString([]byte("some-data"))
+	require.Nil(t, err)
+
+	assert.Equal(t, "some-data", actual)
+}
+
+func TestUnit_Decoder_DecodeJSONOrString_DecodesJSON(t *testing.T) {
+	actual, err := DecodeJSONOrString([]byte(`{"value":12}`))
+	require.Nil(t, err)
+
+	asMap, ok := actual.(map[string]any)
+	require.True(t, ok)
+
+	assert.Equal(t, float64(12), asMap["value"])
+}
+
+func TestUnit_Decoder_DecodeJSONOrString_FallbacksToString(t *testing.T) {
+	actual, err := DecodeJSONOrString([]byte("some-data"))
+	require.Nil(t, err)
+
+	asString, ok := actual.(string)
+	require.True(t, ok)
+	assert.Equal(t, "some-data", asString)
+}

--- a/pkg/rest/response_envelope.go
+++ b/pkg/rest/response_envelope.go
@@ -1,11 +1,7 @@
 package rest
 
-import (
-	"encoding/json"
-)
-
-type responseEnvelope struct {
-	RequestId string          `json:"requestId"`
-	Status    string          `json:"status"`
-	Details   json.RawMessage `json:"details,omitempty"`
+type ResponseEnvelope[T any] struct {
+	RequestId string `json:"requestId"`
+	Status    string `json:"status"`
+	Details   T      `json:"details"`
 }

--- a/pkg/rest/response_envelope_test.go
+++ b/pkg/rest/response_envelope_test.go
@@ -7,11 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUnit_ResponseEnvelope_MarshalsToCamelCase(t *testing.T) {
-	r := responseEnvelope{
+func TestUnit_ResponseEnvelope_SuccessfullyMarshalsTypedDetails(t *testing.T) {
+	type details struct {
+		Field int `json:"field"`
+	}
+
+	r := ResponseEnvelope[details]{
 		RequestId: "1348f004-7620-4c80-915d-26da0ac144f6",
 		Status:    "SUCCESS",
-		Details:   json.RawMessage([]byte(`{"Field":32}`)),
+		Details:   details{Field: 32},
 	}
 
 	out, err := json.Marshal(r)
@@ -22,8 +26,27 @@ func TestUnit_ResponseEnvelope_MarshalsToCamelCase(t *testing.T) {
 		"requestId": "1348f004-7620-4c80-915d-26da0ac144f6",
 		"status": "SUCCESS",
 		"details": {
-			"Field": 32
+			"field": 32
 		}
+	}`
+	assert.JSONEq(t, expectedJson, string(out))
+}
+
+func TestUnit_ResponseEnvelope_SuccessfullyMarshalsSimpleDetails(t *testing.T) {
+	r := ResponseEnvelope[int32]{
+		RequestId: "1348f004-7620-4c80-915d-26da0ac144f6",
+		Status:    "SUCCESS",
+		Details:   int32(16),
+	}
+
+	out, err := json.Marshal(r)
+
+	assert.Nil(t, err)
+	expectedJson := `
+	{
+		"requestId": "1348f004-7620-4c80-915d-26da0ac144f6",
+		"status": "SUCCESS",
+		"details": 16
 	}`
 	assert.JSONEq(t, expectedJson, string(out))
 }

--- a/pkg/rest/response_envelope_writer.go
+++ b/pkg/rest/response_envelope_writer.go
@@ -6,14 +6,14 @@ import (
 	"net/http"
 )
 
-type envelopeResponseWriter struct {
-	response responseEnvelope
+type envelopeResponseWriter[T any] struct {
+	response ResponseEnvelope[T]
 	writer   http.ResponseWriter
 }
 
-func NewResponseEnvelopeWriter(w http.ResponseWriter, requestId string) *envelopeResponseWriter {
-	return &envelopeResponseWriter{
-		response: responseEnvelope{
+func NewResponseEnvelopeWriter[T any](w http.ResponseWriter, requestId string) *envelopeResponseWriter[T] {
+	return &envelopeResponseWriter[T]{
+		response: ResponseEnvelope[T]{
 			RequestId: requestId,
 			Status:    "SUCCESS",
 		},
@@ -21,23 +21,15 @@ func NewResponseEnvelopeWriter(w http.ResponseWriter, requestId string) *envelop
 	}
 }
 
-func (erw *envelopeResponseWriter) Header() http.Header {
+func (erw *envelopeResponseWriter[T]) Header() http.Header {
 	return erw.writer.Header()
 }
 
-func (erw *envelopeResponseWriter) Write(data []byte) (int, error) {
+func (erw *envelopeResponseWriter[T]) Write(data T) (int, error) {
 	erw.response.Details = data
 	out, err := json.Marshal(erw.response)
 	if err != nil {
-		// Attempt to marshal as string
-		asString := string(data)
-		encodedData, err := json.Marshal(&asString)
-		if err != nil {
-			// Fallback to writing no response envelope
-			return erw.writer.Write(data)
-		}
-
-		return erw.Write(encodedData)
+		return 0, err
 	}
 
 	// Update Content-Length to reflect the actual wrapped payload size
@@ -46,7 +38,7 @@ func (erw *envelopeResponseWriter) Write(data []byte) (int, error) {
 	return erw.writer.Write(out)
 }
 
-func (erw *envelopeResponseWriter) WriteHeader(statusCode int) {
+func (erw *envelopeResponseWriter[T]) WriteHeader(statusCode int) {
 	if statusCode < 200 || statusCode > 299 {
 		erw.response.Status = "ERROR"
 	} else {

--- a/pkg/rest/response_envelope_writer.go
+++ b/pkg/rest/response_envelope_writer.go
@@ -6,18 +6,22 @@ import (
 	"net/http"
 )
 
+type ResponseEnvelopeDecoder[T any] func(data []byte) (T, error)
+
 type envelopeResponseWriter[T any] struct {
 	response ResponseEnvelope[T]
 	writer   http.ResponseWriter
+	decoder  ResponseEnvelopeDecoder[T]
 }
 
-func NewResponseEnvelopeWriter[T any](w http.ResponseWriter, requestId string) *envelopeResponseWriter[T] {
+func NewResponseEnvelopeWriter[T any](w http.ResponseWriter, requestId string, decoder ResponseEnvelopeDecoder[T]) *envelopeResponseWriter[T] {
 	return &envelopeResponseWriter[T]{
 		response: ResponseEnvelope[T]{
 			RequestId: requestId,
 			Status:    "SUCCESS",
 		},
-		writer: w,
+		writer:  w,
+		decoder: decoder,
 	}
 }
 
@@ -25,7 +29,16 @@ func (erw *envelopeResponseWriter[T]) Header() http.Header {
 	return erw.writer.Header()
 }
 
-func (erw *envelopeResponseWriter[T]) Write(data T) (int, error) {
+func (erw *envelopeResponseWriter[T]) Write(data []byte) (int, error) {
+	details, err := erw.decoder(data)
+	if err != nil {
+		return 0, err
+	}
+
+	return erw.WriteTyped(details)
+}
+
+func (erw *envelopeResponseWriter[T]) WriteTyped(data T) (int, error) {
 	erw.response.Details = data
 	out, err := json.Marshal(erw.response)
 	if err != nil {

--- a/pkg/rest/response_envelope_writer_test.go
+++ b/pkg/rest/response_envelope_writer_test.go
@@ -12,12 +12,16 @@ import (
 
 const sampleRequestId = "b8e9de68-3d49-4d40-a9a6-f8f3d3eab8f1"
 
-var sampleJsonData = []byte(`{"value":12}`)
+type details struct {
+	Value int `json:"value"`
+}
+
+var sampleJsonData = details{Value: 12}
 
 func TestUnit_EnvelopeResponseWriter_AutomaticallySetsSuccessStatusWhenNoStatusIsUsed(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter(out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
 
 	rw.Write(sampleJsonData)
 
@@ -39,7 +43,7 @@ func TestUnit_EnvelopeResponseWriter_ForwardsProvidedWriterHeaders(t *testing.T)
 
 	out.Header().Add("Key2", "other-value")
 
-	rw := NewResponseEnvelopeWriter(out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
 	actual := rw.Header()
 
 	expected := http.Header{
@@ -52,7 +56,7 @@ func TestUnit_EnvelopeResponseWriter_ForwardsProvidedWriterHeaders(t *testing.T)
 func TestUnit_EnvelopeResponseWriter_SetsStatusCodeOnCallToWriteHeader(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter(out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
 
 	rw.WriteHeader(http.StatusUnauthorized)
 
@@ -62,7 +66,7 @@ func TestUnit_EnvelopeResponseWriter_SetsStatusCodeOnCallToWriteHeader(t *testin
 func TestUnit_EnvelopeResponseWriter_WrapsSuccessResponse(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter(out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
 
 	rw.WriteHeader(http.StatusCreated)
 	rw.Write(sampleJsonData)
@@ -82,7 +86,7 @@ func TestUnit_EnvelopeResponseWriter_WrapsSuccessResponse(t *testing.T) {
 func TestUnit_EnvelopeResponseWriter_SetsContentLengthToMatchOutput(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter(out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
 
 	rw.WriteHeader(http.StatusCreated)
 	rw.Write(sampleJsonData)
@@ -92,7 +96,9 @@ func TestUnit_EnvelopeResponseWriter_SetsContentLengthToMatchOutput(t *testing.T
 	require.Len(t, lengths, 1)
 
 	// The length accounts for the response envelope and the JSON format
-	expectedLength := fmt.Sprintf("%d", len(sampleJsonData)+82)
+	// 12 is the length of "{"value":12}
+	// 82 is the length of the response envelope wrapper"
+	expectedLength := fmt.Sprintf("%d", 12+82)
 	actualLength := lengths[0]
 
 	assert.Equal(t, expectedLength, actualLength)
@@ -101,7 +107,7 @@ func TestUnit_EnvelopeResponseWriter_SetsContentLengthToMatchOutput(t *testing.T
 func TestUnit_EnvelopeResponseWriter_WrapsErrorResponse(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter(out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
 
 	rw.WriteHeader(http.StatusUnauthorized)
 	rw.Write(sampleJsonData)
@@ -118,10 +124,27 @@ func TestUnit_EnvelopeResponseWriter_WrapsErrorResponse(t *testing.T) {
 	assert.JSONEq(t, expectedJson, out.Body.String())
 }
 
-func TestUnit_EnvelopeResponseWriter_WrapsPlainDataAsDetailsString(t *testing.T) {
+func TestUnit_EnvelopeResponseWriter_WrapsPlainStringAsDetailsString(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter(out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[string](out, sampleRequestId)
+
+	rw.Write("some-data")
+
+	expectedJson := `
+	{
+		"requestId": "b8e9de68-3d49-4d40-a9a6-f8f3d3eab8f1",
+		"status": "SUCCESS",
+		"details": "some-data"
+	}`
+	actual := out.Body.String()
+	assert.JSONEq(t, expectedJson, actual)
+}
+
+func TestUnit_EnvelopeResponseWriter_WrapsRawBytesAsBytes(t *testing.T) {
+	out := httptest.NewRecorder()
+
+	rw := NewResponseEnvelopeWriter[[]byte](out, sampleRequestId)
 
 	rw.Write([]byte("some-data"))
 
@@ -129,7 +152,7 @@ func TestUnit_EnvelopeResponseWriter_WrapsPlainDataAsDetailsString(t *testing.T)
 	{
 		"requestId": "b8e9de68-3d49-4d40-a9a6-f8f3d3eab8f1",
 		"status": "SUCCESS",
-		"details": "some-data"
+		"details": "c29tZS1kYXRh"
 	}`
 	actual := out.Body.String()
 	assert.JSONEq(t, expectedJson, actual)

--- a/pkg/rest/response_envelope_writer_test.go
+++ b/pkg/rest/response_envelope_writer_test.go
@@ -21,9 +21,9 @@ var sampleJsonData = details{Value: 12}
 func TestUnit_EnvelopeResponseWriter_AutomaticallySetsSuccessStatusWhenNoStatusIsUsed(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
 
-	rw.Write(sampleJsonData)
+	rw.WriteTyped(sampleJsonData)
 
 	expectedJson := `
 	{
@@ -43,7 +43,7 @@ func TestUnit_EnvelopeResponseWriter_ForwardsProvidedWriterHeaders(t *testing.T)
 
 	out.Header().Add("Key2", "other-value")
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
 	actual := rw.Header()
 
 	expected := http.Header{
@@ -56,7 +56,7 @@ func TestUnit_EnvelopeResponseWriter_ForwardsProvidedWriterHeaders(t *testing.T)
 func TestUnit_EnvelopeResponseWriter_SetsStatusCodeOnCallToWriteHeader(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
 
 	rw.WriteHeader(http.StatusUnauthorized)
 
@@ -66,10 +66,10 @@ func TestUnit_EnvelopeResponseWriter_SetsStatusCodeOnCallToWriteHeader(t *testin
 func TestUnit_EnvelopeResponseWriter_WrapsSuccessResponse(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
 
 	rw.WriteHeader(http.StatusCreated)
-	rw.Write(sampleJsonData)
+	rw.WriteTyped(sampleJsonData)
 
 	assert.Equal(t, http.StatusCreated, out.Code)
 	expectedJson := `
@@ -86,10 +86,10 @@ func TestUnit_EnvelopeResponseWriter_WrapsSuccessResponse(t *testing.T) {
 func TestUnit_EnvelopeResponseWriter_SetsContentLengthToMatchOutput(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
 
 	rw.WriteHeader(http.StatusCreated)
-	rw.Write(sampleJsonData)
+	rw.WriteTyped(sampleJsonData)
 
 	lengths, ok := rw.Header()["Content-Length"]
 	require.True(t, ok, "Missing Content-Length header")
@@ -107,10 +107,10 @@ func TestUnit_EnvelopeResponseWriter_SetsContentLengthToMatchOutput(t *testing.T
 func TestUnit_EnvelopeResponseWriter_WrapsErrorResponse(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
 
 	rw.WriteHeader(http.StatusUnauthorized)
-	rw.Write(sampleJsonData)
+	rw.WriteTyped(sampleJsonData)
 
 	assert.Equal(t, http.StatusUnauthorized, out.Code)
 	expectedJson := `
@@ -127,9 +127,9 @@ func TestUnit_EnvelopeResponseWriter_WrapsErrorResponse(t *testing.T) {
 func TestUnit_EnvelopeResponseWriter_WrapsPlainStringAsDetailsString(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[string](out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[string](out, sampleRequestId, DecodeString)
 
-	rw.Write("some-data")
+	rw.WriteTyped("some-data")
 
 	expectedJson := `
 	{
@@ -144,15 +144,35 @@ func TestUnit_EnvelopeResponseWriter_WrapsPlainStringAsDetailsString(t *testing.
 func TestUnit_EnvelopeResponseWriter_WrapsRawBytesAsBytes(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[[]byte](out, sampleRequestId)
+	rw := NewResponseEnvelopeWriter[[]byte](out, sampleRequestId, DecodeRawBytes)
 
-	rw.Write([]byte("some-data"))
+	rw.WriteTyped([]byte("some-data"))
 
 	expectedJson := `
 	{
 		"requestId": "b8e9de68-3d49-4d40-a9a6-f8f3d3eab8f1",
 		"status": "SUCCESS",
 		"details": "c29tZS1kYXRh"
+	}`
+	actual := out.Body.String()
+	assert.JSONEq(t, expectedJson, actual)
+}
+
+func TestUnit_EnvelopeResponseWriter_DecodesJsonOrStringWhenWritingBytes(t *testing.T) {
+	out := httptest.NewRecorder()
+
+	rw := NewResponseEnvelopeWriter[any](out, sampleRequestId, DecodeJSONOrString)
+
+	_, err := rw.Write([]byte(`{"value":12}`))
+	require.Nil(t, err)
+
+	expectedJson := `
+	{
+		"requestId": "b8e9de68-3d49-4d40-a9a6-f8f3d3eab8f1",
+		"status": "SUCCESS",
+		"details": {
+			"value": 12
+		}
 	}`
 	actual := out.Body.String()
 	assert.JSONEq(t, expectedJson, actual)

--- a/pkg/rest/response_envelope_writer_test.go
+++ b/pkg/rest/response_envelope_writer_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +22,7 @@ var sampleJsonData = details{Value: 12}
 func TestUnit_EnvelopeResponseWriter_AutomaticallySetsSuccessStatusWhenNoStatusIsUsed(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
+	rw := NewResponseEnvelopeWriter(out, sampleRequestId, DecodeJSONTo[details])
 
 	rw.WriteTyped(sampleJsonData)
 
@@ -43,7 +44,7 @@ func TestUnit_EnvelopeResponseWriter_ForwardsProvidedWriterHeaders(t *testing.T)
 
 	out.Header().Add("Key2", "other-value")
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
+	rw := NewResponseEnvelopeWriter(out, sampleRequestId, DecodeJSONTo[details])
 	actual := rw.Header()
 
 	expected := http.Header{
@@ -56,7 +57,7 @@ func TestUnit_EnvelopeResponseWriter_ForwardsProvidedWriterHeaders(t *testing.T)
 func TestUnit_EnvelopeResponseWriter_SetsStatusCodeOnCallToWriteHeader(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
+	rw := NewResponseEnvelopeWriter(out, sampleRequestId, DecodeJSONTo[details])
 
 	rw.WriteHeader(http.StatusUnauthorized)
 
@@ -66,7 +67,7 @@ func TestUnit_EnvelopeResponseWriter_SetsStatusCodeOnCallToWriteHeader(t *testin
 func TestUnit_EnvelopeResponseWriter_WrapsSuccessResponse(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
+	rw := NewResponseEnvelopeWriter(out, sampleRequestId, DecodeJSONTo[details])
 
 	rw.WriteHeader(http.StatusCreated)
 	rw.WriteTyped(sampleJsonData)
@@ -86,7 +87,7 @@ func TestUnit_EnvelopeResponseWriter_WrapsSuccessResponse(t *testing.T) {
 func TestUnit_EnvelopeResponseWriter_SetsContentLengthToMatchOutput(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
+	rw := NewResponseEnvelopeWriter(out, sampleRequestId, DecodeJSONTo[details])
 
 	rw.WriteHeader(http.StatusCreated)
 	rw.WriteTyped(sampleJsonData)
@@ -107,7 +108,7 @@ func TestUnit_EnvelopeResponseWriter_SetsContentLengthToMatchOutput(t *testing.T
 func TestUnit_EnvelopeResponseWriter_WrapsErrorResponse(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[details](out, sampleRequestId, DecodeJSONTo[details])
+	rw := NewResponseEnvelopeWriter(out, sampleRequestId, DecodeJSONTo[details])
 
 	rw.WriteHeader(http.StatusUnauthorized)
 	rw.WriteTyped(sampleJsonData)
@@ -127,7 +128,7 @@ func TestUnit_EnvelopeResponseWriter_WrapsErrorResponse(t *testing.T) {
 func TestUnit_EnvelopeResponseWriter_WrapsPlainStringAsDetailsString(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[string](out, sampleRequestId, DecodeString)
+	rw := NewResponseEnvelopeWriter(out, sampleRequestId, DecodeString)
 
 	rw.WriteTyped("some-data")
 
@@ -144,9 +145,9 @@ func TestUnit_EnvelopeResponseWriter_WrapsPlainStringAsDetailsString(t *testing.
 func TestUnit_EnvelopeResponseWriter_WrapsRawBytesAsBytes(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[[]byte](out, sampleRequestId, DecodeRawBytes)
+	rw := NewResponseEnvelopeWriter(out, sampleRequestId, DecodeRawBytes)
 
-	rw.WriteTyped([]byte("some-data"))
+	rw.Write([]byte("some-data"))
 
 	expectedJson := `
 	{
@@ -161,7 +162,7 @@ func TestUnit_EnvelopeResponseWriter_WrapsRawBytesAsBytes(t *testing.T) {
 func TestUnit_EnvelopeResponseWriter_DecodesJsonOrStringWhenWritingBytes(t *testing.T) {
 	out := httptest.NewRecorder()
 
-	rw := NewResponseEnvelopeWriter[any](out, sampleRequestId, DecodeJSONOrString)
+	rw := NewResponseEnvelopeWriter(out, sampleRequestId, DecodeJSONOrString)
 
 	_, err := rw.Write([]byte(`{"value":12}`))
 	require.Nil(t, err)
@@ -173,6 +174,48 @@ func TestUnit_EnvelopeResponseWriter_DecodesJsonOrStringWhenWritingBytes(t *test
 		"details": {
 			"value": 12
 		}
+	}`
+	actual := out.Body.String()
+	assert.JSONEq(t, expectedJson, actual)
+}
+
+func TestUnit_EnvelopeResponseWriter_DecodesJsonWhenWritingBytes(t *testing.T) {
+	out := httptest.NewRecorder()
+
+	rw := NewResponseEnvelopeWriter(out, sampleRequestId, DecodeJSONOrString)
+
+	value := details{Value: 45}
+	data, err := json.Marshal(value)
+	require.Nil(t, err, "Actual err: %v", err)
+
+	_, err = rw.Write(data)
+	require.Nil(t, err)
+
+	expectedJson := `
+	{
+		"requestId": "b8e9de68-3d49-4d40-a9a6-f8f3d3eab8f1",
+		"status": "SUCCESS",
+		"details": {
+			"value": 45
+		}
+	}`
+	actual := out.Body.String()
+	assert.JSONEq(t, expectedJson, actual)
+}
+
+func TestUnit_EnvelopeResponseWriter_DecodesStringWhenWritingBytes(t *testing.T) {
+	out := httptest.NewRecorder()
+
+	rw := NewResponseEnvelopeWriter(out, sampleRequestId, DecodeJSONOrString)
+
+	_, err := rw.Write([]byte("An error occurred"))
+	require.Nil(t, err)
+
+	expectedJson := `
+	{
+		"requestId": "b8e9de68-3d49-4d40-a9a6-f8f3d3eab8f1",
+		"status": "SUCCESS",
+		"details": "An error occurred"
 	}`
 	actual := out.Body.String()
 	assert.JSONEq(t, expectedJson, actual)


### PR DESCRIPTION
# Work

The response envelope is currently an unexported which does not make it easy to generate specs for it. It also hides the logic from consumer code.

To make it easier to use, this PR makes the response envelope a public type of the project. It also changes the logic so that the consumers need to provide a decoder, allowing to keep the wrapping to raw bytes but also to make it possible to generate specs.

# Tests

New unit tests were added to cover the additional use cases. The existing ones were modified in a minimal way to verify the existing behavior. None of the tests outside of the rest package needed to be updated.

# Future work

This approach will be rolled out so that services can expose proper documentation (such as [galactic-sovereign](https://github.com/Knoblauchpilze/galactic-sovereign) and [user-service](https://github.com/Knoblauchpilze/user-service)).
