### PR TITLE
feat: ErrorWithCode as a struct

### DIFF
--- a/pkg/db/connection.go
+++ b/pkg/db/connection.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	jpgx "github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -49,14 +48,14 @@ func (ci *connectionImpl) Close(ctx context.Context) {
 
 func (ci *connectionImpl) Ping(ctx context.Context) error {
 	if ci.pool == nil {
-		return errors.NewCode(NotConnected)
+		return ErrNotConnected
 	}
 	return ci.pool.Ping(ctx)
 }
 
 func (ci *connectionImpl) BeginTx(ctx context.Context) (Transaction, error) {
 	if ci.pool == nil {
-		return nil, errors.NewCode(NotConnected)
+		return nil, ErrNotConnected
 	}
 
 	pgxTx, err := ci.pool.Begin(ctx)
@@ -74,7 +73,7 @@ func (ci *connectionImpl) BeginTx(ctx context.Context) (Transaction, error) {
 
 func (ci *connectionImpl) Exec(ctx context.Context, sql string, arguments ...any) (int64, error) {
 	if ci.pool == nil {
-		return 0, errors.NewCode(NotConnected)
+		return 0, ErrNotConnected
 	}
 
 	tag, err := ci.pool.Exec(ctx, sql, arguments...)
@@ -87,7 +86,7 @@ func (ci *connectionImpl) Exec(ctx context.Context, sql string, arguments ...any
 
 func (ci *connectionImpl) query(ctx context.Context, sql string, arguments ...any) (jpgx.Rows, error) {
 	if ci.pool == nil {
-		return nil, errors.NewCode(NotConnected)
+		return nil, ErrNotConnected
 	}
 	rows, err := ci.pool.Query(ctx, sql, arguments...)
 

--- a/pkg/db/connection_test.go
+++ b/pkg/db/connection_test.go
@@ -31,7 +31,7 @@ func TestIT_New_ValidConfiguration_InvalidCredentials(t *testing.T) {
 	conn, err := New(context.Background(), config)
 
 	assert.NotNil(t, conn)
-	assert.True(t, errors.IsErrorWithCode(err, pgx.AuthenticationFailed), "Actual err: %v", err)
+	assert.Equal(t, pgx.ErrAuthenticationFailed, err, "Actual err: %v", err)
 }
 
 func TestIT_New_ValidConfiguration(t *testing.T) {
@@ -56,7 +56,7 @@ func TestIT_Connection_Close(t *testing.T) {
 
 	conn.Close(context.Background())
 	err = conn.Ping(context.Background())
-	assert.True(t, errors.IsErrorWithCode(err, NotConnected), "Actual err: %v", err)
+	assert.Equal(t, ErrNotConnected, err, "Actual err: %v", err)
 }
 
 func TestIT_Connection_BeginTx_TimeStampIsValid(t *testing.T) {
@@ -76,7 +76,7 @@ func TestIT_Connection_BeginTx_ClosedConnection(t *testing.T) {
 	tx, err := conn.BeginTx(context.Background())
 
 	assert.Nil(t, tx)
-	assert.True(t, errors.IsErrorWithCode(err, NotConnected), "Actual err: %v", err)
+	assert.Equal(t, ErrNotConnected, err, "Actual err: %v", err)
 }
 
 func TestIT_Connection_Exec_Select(t *testing.T) {
@@ -111,7 +111,9 @@ func TestIT_Connection_Exec_InsertDuplicate(t *testing.T) {
 	affectedRows, err := conn.Exec(context.Background(), "INSERT INTO my_table VALUES ($1, $2)", id, element.Name)
 
 	assert.Equal(t, int64(0), affectedRows)
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := errors.AsErrorWithCode(err)
+	require.True(t, ok)
+	assert.Equal(t, pgx.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 	assertIdDoesNotExist(t, conn, id)
 }
 
@@ -134,7 +136,9 @@ func TestIT_Connection_Exec_UpdateDuplicate(t *testing.T) {
 
 	affectedRows, err := conn.Exec(context.Background(), "UPDATE my_table SET name = $1 WHERE id = $2", anotherElement.Name, element.Id)
 	assert.Equal(t, int64(0), affectedRows)
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := errors.AsErrorWithCode(err)
+	require.True(t, ok)
+	assert.Equal(t, pgx.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 
 	assertNameForId(t, conn, element.Id, element.Name)
 }
@@ -167,7 +171,9 @@ func TestIT_Connection_Exec_WrongSyntax(t *testing.T) {
 	affectedRows, err := conn.Exec(context.Background(), "DESELECT COUNT(*) FROM my_table WHERE name = $1", element.Name)
 
 	assert.Equal(t, int64(0), affectedRows)
-	assert.True(t, errors.IsErrorWithCode(err, pgx.GenericSqlError), "Actual err: %v", err)
+	actual, ok := errors.AsErrorWithCode(err)
+	require.True(t, ok)
+	assert.Equal(t, pgx.ErrGenericSqlError, actual.Code, "Actual err: %v", err)
 }
 
 func TestIT_Connection_Exec_ReturnsZonedTimeAsUTC(t *testing.T) {

--- a/pkg/db/errors.go
+++ b/pkg/db/errors.go
@@ -3,10 +3,19 @@ package db
 import "github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 
 const (
-	NotConnected         errors.ErrorCode = 100
-	UnsupportedOperation errors.ErrorCode = 101
-	AlreadyCommitted     errors.ErrorCode = 102
+	errNotConnected         errors.ErrorCode = 100
+	errUnsupportedOperation errors.ErrorCode = 101
+	errAlreadyCommitted     errors.ErrorCode = 102
 
-	NoMatchingRows      errors.ErrorCode = 110
-	TooManyMatchingRows errors.ErrorCode = 111
+	errNoMatchingRows      errors.ErrorCode = 110
+	errTooManyMatchingRows errors.ErrorCode = 111
+)
+
+var (
+	ErrNotConnected         = errors.FromCode(errNotConnected)
+	ErrUnsupportedOperation = errors.FromCode(errUnsupportedOperation)
+	ErrAlreadyCommitted     = errors.FromCode(errAlreadyCommitted)
+
+	ErrNoMatchingRows      = errors.FromCode(errNoMatchingRows)
+	ErrTooManyMatchingRows = errors.FromCode(errTooManyMatchingRows)
 )

--- a/pkg/db/pgx/connection_pool_test.go
+++ b/pkg/db/pgx/connection_pool_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,19 +37,21 @@ func TestIT_New_ConnectsToDatabase(t *testing.T) {
 
 func TestIT_New_ConnectsToDatabase_WrongCredentials(t *testing.T) {
 	type testCase struct {
+		name          string
 		connStr       string
-		expectedError errors.ErrorCode
+		expectedError error
 	}
 
 	testCases := []testCase{
 		{
+			name:          "invalid password",
 			connStr:       "postgres://test_user:comes-from-the-environment@localhost:5432/test_db",
-			expectedError: AuthenticationFailed,
+			expectedError: ErrAuthenticationFailed,
 		},
 	}
 
 	for _, testCase := range testCases {
-		t.Run("", func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			pool, err := New(context.Background(), testCase.connStr)
 			require.Nil(t, err)
 
@@ -58,7 +59,7 @@ func TestIT_New_ConnectsToDatabase_WrongCredentials(t *testing.T) {
 			require.NotNil(t, err)
 
 			actual := AnalyzeAndWrapPgError(err)
-			assert.True(t, errors.IsErrorWithCode(actual, testCase.expectedError), "Actual err: %v", err)
+			assert.Equal(t, actual, testCase.expectedError, "Actual err: %v", err)
 		})
 	}
 

--- a/pkg/db/pgx/errors.go
+++ b/pkg/db/pgx/errors.go
@@ -3,8 +3,12 @@ package pgx
 import "github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 
 const (
-	GenericSqlError           errors.ErrorCode = 150
-	ForeignKeyValidation      errors.ErrorCode = 151
-	UniqueConstraintViolation errors.ErrorCode = 152
-	AuthenticationFailed      errors.ErrorCode = 153
+	ErrGenericSqlError           errors.ErrorCode = 150
+	ErrForeignKeyValidation      errors.ErrorCode = 151
+	ErrUniqueConstraintViolation errors.ErrorCode = 152
+	errAuthenticationFailed      errors.ErrorCode = 153
+)
+
+var (
+	ErrAuthenticationFailed = errors.FromCode(errAuthenticationFailed)
 )

--- a/pkg/db/pgx/pg_error.go
+++ b/pkg/db/pgx/pg_error.go
@@ -37,19 +37,19 @@ func AnalyzeAndWrapPgError(err error) error {
 func analyzePgError(err *pgconn.PgError) error {
 	switch err.Code {
 	case foreignKeyViolation:
-		return errors.WrapCode(err, ForeignKeyValidation)
+		return errors.WrapCode(err, ErrForeignKeyValidation)
 	case uniqueValidation:
-		return errors.WrapCode(err, UniqueConstraintViolation)
+		return errors.WrapCode(err, ErrUniqueConstraintViolation)
 	}
 
-	return errors.WrapCode(err, GenericSqlError)
+	return errors.WrapCode(err, ErrGenericSqlError)
 }
 
 func analyzeConnError(err *pgconn.ConnectError) error {
 	msg := err.Unwrap().Error()
 	if strings.Contains(msg, passwordAuthenticationFailed) {
-		return errors.NewCodeWithDetails(AuthenticationFailed, "Failed to connect to database")
+		return ErrAuthenticationFailed
 	}
 
-	return errors.NewCode(GenericSqlError)
+	return errors.FromCode(ErrGenericSqlError)
 }

--- a/pkg/db/pgx/pg_error_test.go
+++ b/pkg/db/pgx/pg_error_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
-	jpgx "github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnit_AnalyzeAndWrapPgError_Nil(t *testing.T) {
@@ -32,29 +33,35 @@ func TestUnit_AnalyzeAndWrapPgError_PgError(t *testing.T) {
 	testCases := []testCase{
 		{
 			code:          "23503",
-			expectedError: ForeignKeyValidation,
+			expectedError: ErrForeignKeyValidation,
 		},
 		{
 			code:          "23505",
-			expectedError: UniqueConstraintViolation,
+			expectedError: ErrUniqueConstraintViolation,
 		},
 		{
 			code:          "not-a-code",
-			expectedError: GenericSqlError,
+			expectedError: ErrGenericSqlError,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run("", func(t *testing.T) {
-			err := &jpgx.PgError{
+			err := &pgconn.PgError{
 				Code: testCase.code,
 			}
 
-			actual := AnalyzeAndWrapPgError(err)
+			rawErr := AnalyzeAndWrapPgError(err)
 
-			assert.True(t, errors.IsErrorWithCode(actual, testCase.expectedError), "Actual err: %v", err)
-			cause := errors.Unwrap(actual)
-			assert.Equal(t, err, cause)
+			actual, ok := errors.AsErrorWithCode(rawErr)
+			require.True(t, ok)
+
+			expected := &errors.ErrorWithCode{
+				Code:    testCase.expectedError,
+				Message: "an unexpected error occurred",
+				Cause:   err,
+			}
+			assert.Equal(t, expected, actual)
 		})
 	}
 }

--- a/pkg/db/query.go
+++ b/pkg/db/query.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	jpgx "github.com/jackc/pgx/v5"
 )
 
@@ -15,7 +14,7 @@ func QueryOne[T any](ctx context.Context, conn Connection, sql string, arguments
 
 	connImpl, ok := conn.(*connectionImpl)
 	if !ok {
-		return out, errors.NewCode(UnsupportedOperation)
+		return out, ErrUnsupportedOperation
 	}
 	rows, err := connImpl.query(ctx, sql, arguments...)
 	if err != nil {
@@ -26,9 +25,9 @@ func QueryOne[T any](ctx context.Context, conn Connection, sql string, arguments
 	if err != nil {
 		switch err {
 		case jpgx.ErrNoRows:
-			return out, errors.WrapCode(err, NoMatchingRows)
+			return out, ErrNoMatchingRows
 		case jpgx.ErrTooManyRows:
-			return out, errors.WrapCode(err, TooManyMatchingRows)
+			return out, ErrTooManyMatchingRows
 		default:
 			return out, pgx.AnalyzeAndWrapPgError(err)
 		}
@@ -42,7 +41,7 @@ func QueryAll[T any](ctx context.Context, conn Connection, sql string, arguments
 
 	connImpl, ok := conn.(*connectionImpl)
 	if !ok {
-		return out, errors.NewCode(UnsupportedOperation)
+		return out, ErrUnsupportedOperation
 	}
 	rows, err := connImpl.query(ctx, sql, arguments...)
 	if err != nil {
@@ -51,7 +50,7 @@ func QueryAll[T any](ctx context.Context, conn Connection, sql string, arguments
 
 	out, err = jpgx.CollectRows(rows, getCollectorForType[T]())
 	if err != nil {
-		return out, errors.WrapCode(err, UnsupportedOperation)
+		return out, ErrUnsupportedOperation
 	}
 
 	return out, nil

--- a/pkg/db/query_test.go
+++ b/pkg/db/query_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type dummyConnection struct {
@@ -21,7 +22,7 @@ func TestUnit_QueryOne_UnsupportedConnection(t *testing.T) {
 	_, err := QueryOne[int](context.Background(), &dummyConnection{}, sampleSqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, UnsupportedOperation), "Actual err: %v", err)
+	assert.Equal(t, ErrUnsupportedOperation, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryOne_WhenClosed_ExpectFailure(t *testing.T) {
@@ -31,7 +32,7 @@ func TestIT_QueryOne_WhenClosed_ExpectFailure(t *testing.T) {
 	_, err := QueryOne[int](context.Background(), conn, sampleSqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, NotConnected), "Actual err: %v", err)
+	assert.Equal(t, ErrNotConnected, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryOne_WhenConnectionFails_ExpectFailure(t *testing.T) {
@@ -41,7 +42,9 @@ func TestIT_QueryOne_WhenConnectionFails_ExpectFailure(t *testing.T) {
 	_, err := QueryOne[string](context.Background(), conn, sqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, pgx.GenericSqlError), "Actual err: %v", err)
+	actual, ok := errors.AsErrorWithCode(err)
+	require.True(t, ok)
+	assert.Equal(t, pgx.ErrGenericSqlError, actual.Code, "Actual err: %v", err)
 
 	cause := errors.Unwrap(err)
 	assert.NotNil(t, cause)
@@ -54,7 +57,7 @@ func TestIT_QueryOne_WhenNoData_ExpectFailure(t *testing.T) {
 	_, err := QueryOne[element](context.Background(), conn, sqlQuery, "does-not-exist")
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, NoMatchingRows), "Actual err: %v", err)
+	assert.Equal(t, ErrNoMatchingRows, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryOne_WhenTooManyRows_ExpectFailure(t *testing.T) {
@@ -66,7 +69,7 @@ func TestIT_QueryOne_WhenTooManyRows_ExpectFailure(t *testing.T) {
 	_, err := QueryOne[element](context.Background(), conn, sqlQuery, v1.Id, v2.Id)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, TooManyMatchingRows), "Actual err: %v", err)
+	assert.Equal(t, ErrTooManyMatchingRows, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryOne_WhenUniqueConstraintViolation_ExpectFailure(t *testing.T) {
@@ -81,7 +84,9 @@ func TestIT_QueryOne_WhenUniqueConstraintViolation_ExpectFailure(t *testing.T) {
 	sqlQuery := "INSERT INTO my_table (id, name) VALUES($1, $2)"
 	_, err := QueryOne[element](context.Background(), conn, sqlQuery, duplicate.Id, duplicate.Name)
 
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := errors.AsErrorWithCode(err)
+	require.True(t, ok)
+	assert.Equal(t, pgx.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 }
 
 func TestIT_QueryOne_ToStruct(t *testing.T) {
@@ -133,7 +138,7 @@ func TestIT_QueryAll_UnsupportedConnection(t *testing.T) {
 	_, err := QueryAll[int](context.Background(), &dummyConnection{}, sampleSqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, UnsupportedOperation), "Actual err: %v", err)
+	assert.Equal(t, ErrUnsupportedOperation, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryAll_WhenClosed_ExpectFailure(t *testing.T) {
@@ -143,7 +148,7 @@ func TestIT_QueryAll_WhenClosed_ExpectFailure(t *testing.T) {
 	_, err := QueryAll[int](context.Background(), conn, sampleSqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, NotConnected), "Actual err: %v", err)
+	assert.Equal(t, ErrNotConnected, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryAll_WhenConnectionFails_ExpectFailure(t *testing.T) {
@@ -153,7 +158,9 @@ func TestIT_QueryAll_WhenConnectionFails_ExpectFailure(t *testing.T) {
 	_, err := QueryAll[string](context.Background(), conn, sqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, pgx.GenericSqlError), "Actual err: %v", err)
+	actual, ok := errors.AsErrorWithCode(err)
+	require.True(t, ok)
+	assert.Equal(t, pgx.ErrGenericSqlError, actual.Code, "Actual err: %v", err)
 
 	cause := errors.Unwrap(err)
 	assert.NotNil(t, cause)

--- a/pkg/db/query_tx.go
+++ b/pkg/db/query_tx.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	jpgx "github.com/jackc/pgx/v5"
 )
 
@@ -13,7 +12,7 @@ func QueryOneTx[T any](ctx context.Context, tx Transaction, sql string, argument
 
 	txImpl, ok := tx.(*transactionImpl)
 	if !ok {
-		return out, errors.NewCode(UnsupportedOperation)
+		return out, ErrUnsupportedOperation
 	}
 	rows, err := txImpl.query(ctx, sql, arguments...)
 	if err != nil {
@@ -24,9 +23,9 @@ func QueryOneTx[T any](ctx context.Context, tx Transaction, sql string, argument
 	if err != nil {
 		switch err {
 		case jpgx.ErrNoRows:
-			return out, errors.WrapCode(err, NoMatchingRows)
+			return out, ErrNoMatchingRows
 		case jpgx.ErrTooManyRows:
-			return out, errors.WrapCode(err, TooManyMatchingRows)
+			return out, ErrTooManyMatchingRows
 		default:
 			return out, pgx.AnalyzeAndWrapPgError(err)
 		}
@@ -40,7 +39,7 @@ func QueryAllTx[T any](ctx context.Context, tx Transaction, sql string, argument
 
 	txImpl, ok := tx.(*transactionImpl)
 	if !ok {
-		return out, errors.NewCode(UnsupportedOperation)
+		return out, ErrUnsupportedOperation
 	}
 	rows, err := txImpl.query(ctx, sql, arguments...)
 	if err != nil {
@@ -49,7 +48,7 @@ func QueryAllTx[T any](ctx context.Context, tx Transaction, sql string, argument
 
 	out, err = jpgx.CollectRows(rows, getCollectorForType[T]())
 	if err != nil {
-		return out, errors.WrapCode(err, UnsupportedOperation)
+		return out, ErrUnsupportedOperation
 	}
 
 	return out, nil

--- a/pkg/db/query_tx_test.go
+++ b/pkg/db/query_tx_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type dummyTransaction struct {
@@ -19,7 +20,7 @@ func TestUnit_QueryOneTx_UnsupportedConnection(t *testing.T) {
 	_, err := QueryOneTx[int](context.Background(), &dummyTransaction{}, sampleSqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, UnsupportedOperation), "Actual err: %v", err)
+	assert.Equal(t, ErrUnsupportedOperation, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryOneTx_WhenCommitted_ExpectFailure(t *testing.T) {
@@ -29,7 +30,7 @@ func TestIT_QueryOneTx_WhenCommitted_ExpectFailure(t *testing.T) {
 	_, err := QueryOneTx[int](context.Background(), tx, sampleSqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, AlreadyCommitted), "Actual err: %v", err)
+	assert.Equal(t, ErrAlreadyCommitted, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryOneTx_WhenConnectionFails_ExpectFailure(t *testing.T) {
@@ -39,7 +40,9 @@ func TestIT_QueryOneTx_WhenConnectionFails_ExpectFailure(t *testing.T) {
 	_, err := QueryOneTx[string](context.Background(), tx, sqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, pgx.GenericSqlError), "Actual err: %v", err)
+	actual, ok := errors.AsErrorWithCode(err)
+	require.True(t, ok)
+	assert.Equal(t, pgx.ErrGenericSqlError, actual.Code, "Actual err: %v", err)
 
 	cause := errors.Unwrap(err)
 	assert.NotNil(t, cause)
@@ -52,7 +55,7 @@ func TestIT_QueryOneTx_WhenNoData_ExpectFailure(t *testing.T) {
 	_, err := QueryOneTx[element](context.Background(), tx, sqlQuery, "does-not-exist")
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, NoMatchingRows), "Actual err: %v", err)
+	assert.Equal(t, ErrNoMatchingRows, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryOneTx_WhenTooManyRows_ExpectFailure(t *testing.T) {
@@ -64,7 +67,7 @@ func TestIT_QueryOneTx_WhenTooManyRows_ExpectFailure(t *testing.T) {
 	_, err := QueryOneTx[element](context.Background(), tx, sqlQuery, v1.Id, v2.Id)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, TooManyMatchingRows), "Actual err: %v", err)
+	assert.Equal(t, ErrTooManyMatchingRows, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryOneTx_WhenUniqueConstraintViolation_ExpectFailure(t *testing.T) {
@@ -79,7 +82,9 @@ func TestIT_QueryOneTx_WhenUniqueConstraintViolation_ExpectFailure(t *testing.T)
 	sqlQuery := "INSERT INTO my_table (id, name) VALUES($1, $2)"
 	_, err := QueryOneTx[element](context.Background(), tx, sqlQuery, duplicate.Id, duplicate.Name)
 
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := errors.AsErrorWithCode(err)
+	require.True(t, ok)
+	assert.Equal(t, pgx.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 }
 
 func TestIT_QueryOneTx_ToStruct(t *testing.T) {
@@ -131,7 +136,7 @@ func TestIT_QueryAllTx_UnsupportedConnection(t *testing.T) {
 	_, err := QueryAllTx[int](context.Background(), &dummyTransaction{}, sampleSqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, UnsupportedOperation), "Actual err: %v", err)
+	assert.Equal(t, ErrUnsupportedOperation, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryAllTx_WhenCommitted_ExpectFailure(t *testing.T) {
@@ -141,7 +146,7 @@ func TestIT_QueryAllTx_WhenCommitted_ExpectFailure(t *testing.T) {
 	_, err := QueryAllTx[int](context.Background(), tx, sampleSqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, AlreadyCommitted), "Actual err: %v", err)
+	assert.Equal(t, ErrAlreadyCommitted, err, "Actual err: %v", err)
 }
 
 func TestIT_QueryAllTx_WhenConnectionFails_ExpectFailure(t *testing.T) {
@@ -151,7 +156,9 @@ func TestIT_QueryAllTx_WhenConnectionFails_ExpectFailure(t *testing.T) {
 	_, err := QueryAllTx[string](context.Background(), tx, sqlQuery)
 
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsErrorWithCode(err, pgx.GenericSqlError), "Actual err: %v", err)
+	actual, ok := errors.AsErrorWithCode(err)
+	require.True(t, ok)
+	assert.Equal(t, pgx.ErrGenericSqlError, actual.Code, "Actual err: %v", err)
 
 	cause := errors.Unwrap(err)
 	assert.NotNil(t, cause)

--- a/pkg/db/transaction.go
+++ b/pkg/db/transaction.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	jpgx "github.com/jackc/pgx/v5"
 )
 
@@ -38,7 +37,7 @@ func (ti *transactionImpl) TimeStamp() time.Time {
 
 func (ti *transactionImpl) Exec(ctx context.Context, sql string, arguments ...any) (int64, error) {
 	if ti.tx == nil {
-		return int64(0), errors.NewCode(AlreadyCommitted)
+		return int64(0), ErrAlreadyCommitted
 	}
 
 	tag, err := ti.tx.Exec(ctx, sql, arguments...)
@@ -53,7 +52,7 @@ func (ti *transactionImpl) Exec(ctx context.Context, sql string, arguments ...an
 
 func (ti *transactionImpl) query(ctx context.Context, sql string, arguments ...any) (jpgx.Rows, error) {
 	if ti.tx == nil {
-		return nil, errors.NewCode(AlreadyCommitted)
+		return nil, ErrAlreadyCommitted
 	}
 
 	rows, err := ti.tx.Query(ctx, sql, arguments...)

--- a/pkg/db/transaction_test.go
+++ b/pkg/db/transaction_test.go
@@ -18,7 +18,7 @@ func TestIT_Transaction_Exec_AlreadyCommitted(t *testing.T) {
 	affectedRows, err := tx.Exec(context.Background(), "SELECT COUNT(*) FROM my_table WHERE name = 'test-name'")
 
 	assert.Equal(t, int64(0), affectedRows)
-	assert.True(t, errors.IsErrorWithCode(err, AlreadyCommitted), "Actual err: %v", err)
+	assert.Equal(t, ErrAlreadyCommitted, err, "Actual err: %v", err)
 }
 
 func TestIT_Transaction_Exec_Select(t *testing.T) {
@@ -85,7 +85,9 @@ func TestIT_Transaction_Exec_WrongSyntax(t *testing.T) {
 	affectedRows, err := tx.Exec(context.Background(), "DESELECT COUNT(*) FROM my_table WHERE name = 'test-name'")
 
 	assert.Equal(t, int64(0), affectedRows)
-	assert.True(t, errors.IsErrorWithCode(err, pgx.GenericSqlError), "Actual err: %v", err)
+	actual, ok := errors.AsErrorWithCode(err)
+	require.True(t, ok)
+	assert.Equal(t, pgx.ErrGenericSqlError, actual.Code, "Actual err: %v", err)
 }
 
 func TestIT_Transaction_Exec_WhenError_ExpectRollback(t *testing.T) {

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -1,0 +1,8 @@
+package errors
+
+type ErrorCode int
+
+const (
+	GenericErrorCode  ErrorCode = 1
+	errNotImplemented ErrorCode = 2
+)

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -74,6 +75,15 @@ func Unwrap(err error) error {
 	}
 
 	return ie.Cause
+}
+
+func AsErrorWithCode(err error) (*ErrorWithCode, bool) {
+	var errWithCode *ErrorWithCode
+	if errors.As(err, &errWithCode) {
+		return errWithCode, true
+	}
+
+	return nil, false
 }
 
 func (e *ErrorWithCode) Error() string {

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -5,80 +5,59 @@ import (
 	"fmt"
 )
 
-type ErrorCode int
-
-const (
-	GenericErrorCode   ErrorCode = 1
-	NotImplementedCode ErrorCode = 2
-)
-
-type ErrorWithCode interface {
-	Code() ErrorCode
-}
-
-type errorImpl struct {
-	Value   ErrorCode `json:"Code"`
-	Message string
-	Cause   error `json:",omitempty"`
+type ErrorWithCode struct {
+	Code    ErrorCode `json:"code"`
+	Message string    `json:"message"`
+	Cause   error     `json:"cause,omitempty"`
 }
 
 func New(message string) error {
-	return errorImpl{
-		Value:   GenericErrorCode,
+	return &ErrorWithCode{
+		Code:    GenericErrorCode,
 		Message: message,
 	}
 }
 
-func NewCode(code ErrorCode) error {
-	e := errorImpl{
-		Value:   code,
+func FromCode(code ErrorCode) error {
+	return &ErrorWithCode{
+		Code:    code,
 		Message: determineCommonErrorMessage(code),
 	}
-
-	return e
 }
 
-func NotImplemented() error {
-	return NewCode(NotImplementedCode)
-}
-
-func NewCodeWithDetails(code ErrorCode, details string) error {
-	e := errorImpl{
-		Value:   code,
+func FromCodeAndDetails(code ErrorCode, details string) error {
+	return &ErrorWithCode{
+		Code:    code,
 		Message: details,
 	}
-
-	return e
 }
 
 func Newf(format string, args ...interface{}) error {
-	return errorImpl{
-		Value:   GenericErrorCode,
+	return &ErrorWithCode{
+		Code:    GenericErrorCode,
 		Message: fmt.Sprintf(format, args...),
 	}
 }
 
 func Wrap(cause error, message string) error {
-	return errorImpl{
-		Value:   GenericErrorCode,
+	return &ErrorWithCode{
+		Code:    GenericErrorCode,
 		Message: message,
 		Cause:   cause,
 	}
 }
 
 func WrapCode(cause error, code ErrorCode) error {
-	e := errorImpl{
-		Value:   code,
+	return &ErrorWithCode{
+		Code:    code,
 		Message: determineCommonErrorMessage(code),
 		Cause:   cause,
 	}
-
-	return e
 }
 
 func Wrapf(cause error, format string, args ...interface{}) error {
-	return errorImpl{
-		Value:   GenericErrorCode,
+	return &ErrorWithCode{
+		Code:    GenericErrorCode,
 		Message: fmt.Sprintf(format, args...),
 		Cause:   cause,
 	}
@@ -89,7 +68,7 @@ func Unwrap(err error) error {
 		return nil
 	}
 
-	ie, ok := err.(errorImpl)
+	ie, ok := err.(*ErrorWithCode)
 	if !ok {
 		return nil
 	}
@@ -97,23 +76,11 @@ func Unwrap(err error) error {
 	return ie.Cause
 }
 
-func IsErrorWithCode(err error, code ErrorCode) bool {
-	if err == nil {
-		return false
-	}
-
-	if impl, ok := err.(errorImpl); ok {
-		return impl.Code() == code
-	}
-
-	return false
-}
-
-func (e errorImpl) Error() string {
+func (e *ErrorWithCode) Error() string {
 	var out string
 
 	out += e.Message
-	out += fmt.Sprintf(". Code: %d", e.Value)
+	out += fmt.Sprintf(". Code: %d", e.Code)
 
 	if e.Cause != nil {
 		out += fmt.Sprintf(" (cause: %v)", e.Cause.Error())
@@ -122,23 +89,19 @@ func (e errorImpl) Error() string {
 	return out
 }
 
-func (e errorImpl) Code() ErrorCode {
-	return e.Value
-}
-
-func (e errorImpl) MarshalJSON() ([]byte, error) {
+func (e *ErrorWithCode) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Code    ErrorCode
-		Message string          `json:",omitempty"`
-		Cause   json.RawMessage `json:",omitempty"`
+		Code    ErrorCode       `json:"code"`
+		Message string          `json:"message,omitempty"`
+		Cause   json.RawMessage `json:"cause,omitempty"`
 	}{
-		Code:    e.Value,
+		Code:    e.Code,
 		Message: e.Message,
 		Cause:   e.marshalCause(),
 	})
 }
 
-func (e errorImpl) marshalCause() json.RawMessage {
+func (e *ErrorWithCode) marshalCause() json.RawMessage {
 	if e.Cause == nil {
 		return nil
 	}
@@ -147,7 +110,7 @@ func (e errorImpl) marshalCause() json.RawMessage {
 
 	// Voluntarily ignoring the marshalling errors as there's nothing we
 	// can do about it.
-	if impl, ok := e.Cause.(errorImpl); ok {
+	if impl, ok := e.Cause.(*ErrorWithCode); ok {
 		out, _ = json.Marshal(impl)
 	} else {
 		out, _ = json.Marshal(e.Cause.Error())
@@ -158,9 +121,9 @@ func (e errorImpl) marshalCause() json.RawMessage {
 
 func determineCommonErrorMessage(code ErrorCode) string {
 	switch code {
-	case NotImplementedCode:
-		return "Not implemented"
+	case errNotImplemented:
+		return "not implemented"
 	default:
-		return "An unexpected error occurred"
+		return "an unexpected error occurred"
 	}
 }

--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -2,110 +2,144 @@ package errors
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-var errSomeError = fmt.Errorf("some error")
-
 const someCode = ErrorCode(26)
+
+var errSomeError = fmt.Errorf("some error")
 
 func TestUnit_Error_New(t *testing.T) {
 	err := New("foo")
 
-	impl, ok := err.(errorImpl)
-	assert.True(t, ok)
-	assert.Equal(t, "foo", impl.Message)
-	assert.Nil(t, impl.Cause)
-	assert.Equal(t, GenericErrorCode, impl.Value)
-}
+	impl, ok := err.(*ErrorWithCode)
+	require.True(t, ok)
 
-func TestUnit_Error_NewCode(t *testing.T) {
-	err := NewCode(someCode)
-
-	impl, ok := err.(errorImpl)
-	assert.True(t, ok)
-	assert.Equal(t, "An unexpected error occurred", impl.Message)
-	assert.Nil(t, impl.Cause)
-	assert.Equal(t, someCode, impl.Value)
-}
-
-func TestUnit_Error_NewCode_WhenGenericCode_ExpectMessage(t *testing.T) {
-	testCases := []struct {
-		code            ErrorCode
-		expectedMessage string
-	}{
-		{code: NotImplementedCode, expectedMessage: "Not implemented"},
-		{code: GenericErrorCode, expectedMessage: "An unexpected error occurred"},
+	expected := &ErrorWithCode{
+		Code:    GenericErrorCode,
+		Message: "foo",
+		Cause:   nil,
 	}
+	assert.Equal(t, expected, impl)
+}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.expectedMessage, func(t *testing.T) {
-			err := NewCode(testCase.code)
-			impl, ok := err.(errorImpl)
-			assert.True(t, ok)
-			assert.Equal(t, testCase.expectedMessage, impl.Message)
-		})
+func TestUnit_Error_FromCode(t *testing.T) {
+	t.Run("uses generic message when code is not known", func(t *testing.T) {
+		err := FromCode(someCode)
+
+		impl, ok := err.(*ErrorWithCode)
+		require.True(t, ok)
+
+		expected := &ErrorWithCode{
+			Code:    someCode,
+			Message: "an unexpected error occurred",
+			Cause:   nil,
+		}
+		assert.Equal(t, expected, impl)
+	})
+
+	t.Run("correctly maps not implemented code", func(t *testing.T) {
+		err := FromCode(errNotImplemented)
+
+		impl, ok := err.(*ErrorWithCode)
+		require.True(t, ok)
+
+		expected := &ErrorWithCode{
+			Code:    errNotImplemented,
+			Message: "not implemented",
+			Cause:   nil,
+		}
+		assert.Equal(t, expected, impl)
+	})
+
+	t.Run("correctly maps generic code", func(t *testing.T) {
+		err := FromCode(GenericErrorCode)
+
+		impl, ok := err.(*ErrorWithCode)
+		require.True(t, ok)
+
+		expected := &ErrorWithCode{
+			Code:    GenericErrorCode,
+			Message: "an unexpected error occurred",
+			Cause:   nil,
+		}
+		assert.Equal(t, expected, impl)
+	})
+}
+
+func TestUnit_Error_FromCodeAndDetails(t *testing.T) {
+	err := FromCodeAndDetails(someCode, "message")
+
+	impl, ok := err.(*ErrorWithCode)
+	require.True(t, ok)
+
+	expected := &ErrorWithCode{
+		Code:    someCode,
+		Message: "message",
+		Cause:   nil,
 	}
-}
-
-func TestUnit_Error_NewNotImplemented(t *testing.T) {
-	err := NotImplemented()
-
-	impl, ok := err.(errorImpl)
-	assert.True(t, ok)
-	assert.Equal(t, "Not implemented", impl.Message)
-	assert.Nil(t, impl.Cause)
-	assert.Equal(t, NotImplementedCode, impl.Value)
-}
-
-func TestUnit_Error_NewCodeWithDetails(t *testing.T) {
-	err := NewCodeWithDetails(someCode, "message")
-
-	impl, ok := err.(errorImpl)
-	assert.True(t, ok)
-	assert.Equal(t, "message", impl.Message)
-	assert.Nil(t, impl.Cause)
-	assert.Equal(t, someCode, impl.Value)
+	assert.Equal(t, expected, impl)
 }
 
 func TestUnit_Error_Newf(t *testing.T) {
 	err := Newf("foo %d", 22)
 
-	impl, ok := err.(errorImpl)
-	assert.True(t, ok)
-	assert.Equal(t, "foo 22", impl.Message)
-	assert.Nil(t, impl.Cause)
+	impl, ok := err.(*ErrorWithCode)
+	require.True(t, ok)
+
+	expected := &ErrorWithCode{
+		Code:    GenericErrorCode,
+		Message: "foo 22",
+		Cause:   nil,
+	}
+	assert.Equal(t, expected, impl)
 }
 
 func TestUnit_Error_Wrap(t *testing.T) {
 	err := Wrap(errSomeError, "context")
 
-	impl, ok := err.(errorImpl)
-	assert.True(t, ok)
-	assert.Equal(t, "context", impl.Message)
-	assert.Equal(t, errSomeError, impl.Cause)
+	impl, ok := err.(*ErrorWithCode)
+	require.True(t, ok)
+
+	expected := &ErrorWithCode{
+		Code:    GenericErrorCode,
+		Message: "context",
+		Cause:   errSomeError,
+	}
+	assert.Equal(t, expected, impl)
 }
 
 func TestUnit_Error_WrapCode(t *testing.T) {
 	err := WrapCode(errSomeError, someCode)
 
-	impl, ok := err.(errorImpl)
-	assert.True(t, ok)
-	assert.Equal(t, "An unexpected error occurred", impl.Message)
-	assert.Equal(t, errSomeError, impl.Cause)
-	assert.Equal(t, someCode, impl.Value)
+	impl, ok := err.(*ErrorWithCode)
+	require.True(t, ok)
+
+	expected := &ErrorWithCode{
+		Code:    someCode,
+		Message: "an unexpected error occurred",
+		Cause:   errSomeError,
+	}
+	assert.Equal(t, expected, impl)
 }
 
 func TestUnit_Error_Wrapf(t *testing.T) {
 	err := Wrapf(errSomeError, "context %d", -44)
 
-	impl, ok := err.(errorImpl)
-	assert.True(t, ok)
-	assert.Equal(t, "context -44", impl.Message)
-	assert.Equal(t, errSomeError, impl.Cause)
+	impl, ok := err.(*ErrorWithCode)
+	require.True(t, ok)
+
+	expected := &ErrorWithCode{
+		Code:    GenericErrorCode,
+		Message: "context -44",
+		Cause:   errSomeError,
+	}
+	assert.Equal(t, expected, impl)
 }
 
 func TestUnit_Error_Unwrap(t *testing.T) {
@@ -128,80 +162,132 @@ func TestUnit_Error_Unwrap(t *testing.T) {
 }
 
 func TestUnit_Error_Error(t *testing.T) {
-	err := Wrapf(errSomeError, "context %d", -44)
+	t.Run("error returns correct string for error without cause", func(t *testing.T) {
+		err := Newf("context %d", -44)
 
-	expected := "context -44. Code: 1 (cause: some error)"
-	assert.Equal(t, expected, err.Error())
+		expected := "context -44. Code: 1"
+		assert.Equal(t, expected, err.Error())
+	})
 
-	err = WrapCode(errSomeError, someCode)
+	t.Run("error returns correct string for error with cause", func(t *testing.T) {
+		err := Wrapf(errSomeError, "context %d", -44)
 
-	expected = "An unexpected error occurred. Code: 26 (cause: some error)"
-	assert.Equal(t, expected, err.Error())
-}
+		expected := "context -44. Code: 1 (cause: some error)"
+		assert.Equal(t, expected, err.Error())
+	})
 
-func TestUnit_Error_Code(t *testing.T) {
-	err := NewCode(someCode)
+	t.Run("error returns correct string when code is not known", func(t *testing.T) {
+		err := WrapCode(errSomeError, someCode)
 
-	impl, ok := err.(ErrorWithCode)
-	assert.True(t, ok)
-	assert.Equal(t, someCode, impl.Code())
+		expected := "an unexpected error occurred. Code: 26 (cause: some error)"
+		assert.Equal(t, expected, err.Error())
+	})
+
 }
 
 func TestUnit_Error_MarshalJSON(t *testing.T) {
-	err := New("foo")
-	out, mErr := json.Marshal(err)
+	t.Run("marshals error with code", func(t *testing.T) {
+		err := FromCode(someCode)
 
-	expected := `
-	{
+		out, mErr := json.Marshal(err)
+		require.NoError(t, mErr, "Actual err: %v", mErr)
+
+		expected := `
+{
+	"Code": 26,
+	"Message": "An unexpected error occurred"
+}`
+		assert.JSONEq(t, expected, string(out))
+	})
+
+	t.Run("marshals error with details", func(t *testing.T) {
+		err := New("foo")
+
+		out, mErr := json.Marshal(err)
+		require.NoError(t, mErr, "Actual err: %v", mErr)
+
+		expected := `
+{
+	"Code": 1,
+	"Message": "foo"
+}`
+		assert.JSONEq(t, expected, string(out))
+	})
+
+	t.Run("marshals error with cause", func(t *testing.T) {
+		err := Wrap(errSomeError, "hihi")
+
+		out, mErr := json.Marshal(err)
+		require.NoError(t, mErr, "Actual err: %v", mErr)
+
+		expected := `
+{
+	"Code": 1,
+	"Message": "hihi",
+	"Cause": "some error"
+}`
+		assert.JSONEq(t, expected, string(out))
+	})
+
+	t.Run("marshals error with nested error", func(t *testing.T) {
+		err := Wrap(New("foo"), "bar")
+
+		out, mErr := json.Marshal(err)
+		require.NoError(t, mErr, "Actual err: %v", mErr)
+
+		expected := `
+{
+	"Code": 1,
+	"Message": "bar",
+	"Cause": {
 		"Code": 1,
 		"Message": "foo"
-	}`
-	assert.Nil(t, mErr)
-	assert.JSONEq(t, expected, string(out))
-
-	err = NewCode(someCode)
-	out, mErr = json.Marshal(err)
-
-	assert.Nil(t, mErr)
-	expected = `
-	{
-		"Code": 26,
-		"Message": "An unexpected error occurred"
-	}`
-	assert.JSONEq(t, expected, string(out))
-
-	err = Wrap(errSomeError, "hihi")
-	out, mErr = json.Marshal(err)
-
-	expected = `
-	{
-		"Code": 1,
-		"Message": "hihi",
-		"Cause": "some error"
-	}`
-	assert.Nil(t, mErr)
-	assert.JSONEq(t, expected, string(out))
-
-	err = Wrap(New("foo"), "bar")
-	out, mErr = json.Marshal(err)
-
-	expected = `
-	{
-		"Code": 1,
-		"Message": "bar",
-		"Cause": {
-			"Code": 1,
-			"Message": "foo"
-		}
-	}`
-	assert.Nil(t, mErr)
-	assert.JSONEq(t, expected, string(out))
+	}
+}`
+		assert.JSONEq(t, expected, string(out))
+	})
 }
 
-func TestUnit_Error_IsErrorWithCode(t *testing.T) {
-	assert.False(t, IsErrorWithCode(nil, someCode))
-	assert.False(t, IsErrorWithCode(errSomeError, someCode))
-	assert.True(t, IsErrorWithCode(NewCode(someCode), someCode))
-	assert.False(t, IsErrorWithCode(NewCode(27), someCode))
-	assert.False(t, IsErrorWithCode(New("foo"), someCode))
+func TestUnit_Error_Is(t *testing.T) {
+	t.Run("does not detect random error", func(t *testing.T) {
+		var err *ErrorWithCode
+
+		testErr := errors.New("test error")
+		ok := errors.Is(testErr, err)
+
+		assert.False(t, ok)
+		assert.Nil(t, err)
+	})
+
+	t.Run("does not detect error with code", func(t *testing.T) {
+		var err *ErrorWithCode
+
+		testErr := New("test error")
+		ok := errors.Is(testErr, err)
+
+		assert.False(t, ok)
+		assert.Nil(t, err)
+	})
+}
+
+func TestUnit_Error_As(t *testing.T) {
+	t.Run("does not detect random error", func(t *testing.T) {
+		var err *ErrorWithCode
+
+		testErr := errors.New("test error")
+		ok := errors.As(testErr, &err)
+
+		assert.False(t, ok)
+		assert.Nil(t, err)
+	})
+
+	t.Run("does not detect error with code", func(t *testing.T) {
+		var err *ErrorWithCode
+
+		testErr := New("test error")
+		ok := errors.As(testErr, &err)
+
+		require.True(t, ok)
+		assert.Equal(t, testErr, err)
+	})
 }

--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -161,6 +161,24 @@ func TestUnit_Error_Unwrap(t *testing.T) {
 	assert.Nil(t, causeOfCause)
 }
 
+func TestUnit_Error_AsErrorWithCode(t *testing.T) {
+	t.Run("does not detect random error", func(t *testing.T) {
+		testErr := errors.New("test error")
+		actual, ok := AsErrorWithCode(testErr)
+
+		assert.False(t, ok)
+		assert.Nil(t, actual)
+	})
+
+	t.Run("does not detect error with code", func(t *testing.T) {
+		testErr := New("test error")
+		actual, ok := AsErrorWithCode(testErr)
+
+		require.True(t, ok)
+		assert.Equal(t, testErr, actual)
+	})
+}
+
 func TestUnit_Error_Error(t *testing.T) {
 	t.Run("error returns correct string for error without cause", func(t *testing.T) {
 		err := Newf("context %d", -44)
@@ -194,8 +212,8 @@ func TestUnit_Error_MarshalJSON(t *testing.T) {
 
 		expected := `
 {
-	"Code": 26,
-	"Message": "An unexpected error occurred"
+	"code": 26,
+	"message": "an unexpected error occurred"
 }`
 		assert.JSONEq(t, expected, string(out))
 	})
@@ -208,8 +226,8 @@ func TestUnit_Error_MarshalJSON(t *testing.T) {
 
 		expected := `
 {
-	"Code": 1,
-	"Message": "foo"
+	"code": 1,
+	"message": "foo"
 }`
 		assert.JSONEq(t, expected, string(out))
 	})
@@ -222,9 +240,9 @@ func TestUnit_Error_MarshalJSON(t *testing.T) {
 
 		expected := `
 {
-	"Code": 1,
-	"Message": "hihi",
-	"Cause": "some error"
+	"code": 1,
+	"message": "hihi",
+	"cause": "some error"
 }`
 		assert.JSONEq(t, expected, string(out))
 	})
@@ -237,11 +255,11 @@ func TestUnit_Error_MarshalJSON(t *testing.T) {
 
 		expected := `
 {
-	"Code": 1,
-	"Message": "bar",
-	"Cause": {
-		"Code": 1,
-		"Message": "foo"
+	"code": 1,
+	"message": "bar",
+	"cause": {
+		"code": 1,
+		"message": "foo"
 	}
 }`
 		assert.JSONEq(t, expected, string(out))

--- a/pkg/errors/sentinels.go
+++ b/pkg/errors/sentinels.go
@@ -1,0 +1,5 @@
+package errors
+
+var (
+	ErrNotImplemented = FromCode(errNotImplemented)
+)

--- a/pkg/middleware/error_converter_test.go
+++ b/pkg/middleware/error_converter_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,14 +30,14 @@ func TestUnit_ErrorConverter_WrapsUnknownErrorIntoHttpError(t *testing.T) {
 }
 
 func TestUnit_ErrorConverter_WrapsErrorWithCodeIntoHttpError(t *testing.T) {
-	next := createErrorHandler(errors.NewCode(UncaughtPanic))
+	next := createErrorHandler(ErrUncaughtPanic)
 	middleware := ErrorConverter()
 	callable := middleware(next)
 	ctx, _ := generateTestEchoContext()
 
 	err := callable(ctx)
 
-	assertIsHttpErrorWithMessageAndCode(t, err, "An unexpected error occurred. Code: 400", http.StatusInternalServerError)
+	assertIsHttpErrorWithMessageAndCode(t, err, "an unexpected error occurred. Code: 400", http.StatusInternalServerError)
 }
 
 func createErrorHandler(err error) echo.HandlerFunc {

--- a/pkg/middleware/errors.go
+++ b/pkg/middleware/errors.go
@@ -3,5 +3,9 @@ package middleware
 import "github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 
 const (
-	UncaughtPanic errors.ErrorCode = 400
+	errUncaughtPanic errors.ErrorCode = 400
+)
+
+var (
+	ErrUncaughtPanic = errors.FromCode(errUncaughtPanic)
 )

--- a/pkg/middleware/utils.go
+++ b/pkg/middleware/utils.go
@@ -15,8 +15,8 @@ func wrapToHttpError(err error) error {
 	}
 
 	code := http.StatusInternalServerError
-	if errorWithCode, ok := err.(errors.ErrorWithCode); ok {
-		code = errorCodeToHttpErrorCode(errorWithCode.Code())
+	if errorWithCode, ok := err.(*errors.ErrorWithCode); ok {
+		code = errorCodeToHttpErrorCode(errorWithCode.Code)
 	}
 
 	return echo.NewHTTPError(code, err.Error())

--- a/pkg/middleware/utils_test.go
+++ b/pkg/middleware/utils_test.go
@@ -13,21 +13,34 @@ func TestUnit_WrapToHttpError(t *testing.T) {
 
 	actual := wrapToHttpError(err)
 
-	assertIsHttpErrorWithMessageAndCode(t, actual, "some error", http.StatusInternalServerError)
+	assertIsHttpErrorWithMessageAndCode(
+		t,
+		actual,
+		"some error",
+		http.StatusInternalServerError,
+	)
 }
 
 func TestUnit_WrapToHttpError_ErrorWithCode(t *testing.T) {
-	err := errors.NewCode(UncaughtPanic)
+	actual := wrapToHttpError(ErrUncaughtPanic)
 
-	actual := wrapToHttpError(err)
-
-	assertIsHttpErrorWithMessageAndCode(t, actual, "An unexpected error occurred. Code: 400", http.StatusInternalServerError)
+	assertIsHttpErrorWithMessageAndCode(
+		t,
+		actual,
+		"an unexpected error occurred. Code: 400",
+		http.StatusInternalServerError,
+	)
 }
 
 func TestUnit_WrapToHttpError_ErrorWithCodeWithCause(t *testing.T) {
-	err := errors.WrapCode(fmt.Errorf("some error"), UncaughtPanic)
+	err := errors.WrapCode(fmt.Errorf("some error"), errUncaughtPanic)
 
 	actual := wrapToHttpError(err)
 
-	assertIsHttpErrorWithMessageAndCode(t, actual, "An unexpected error occurred. Code: 400 (cause: some error)", http.StatusInternalServerError)
+	assertIsHttpErrorWithMessageAndCode(
+		t,
+		actual,
+		"an unexpected error occurred. Code: 400 (cause: some error)",
+		http.StatusInternalServerError,
+	)
 }

--- a/pkg/process/errors.go
+++ b/pkg/process/errors.go
@@ -3,5 +3,9 @@ package process
 import "github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 
 const (
-	ErrInvalidProcess errors.ErrorCode = 200
+	errInvalidProcess errors.ErrorCode = 200
+)
+
+var (
+	ErrInvalidProcess = errors.FromCode(errInvalidProcess)
 )

--- a/pkg/process/signal_handler.go
+++ b/pkg/process/signal_handler.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 )
 
 var defaultSignals = []os.Signal{
@@ -21,7 +19,7 @@ func AsyncStartWithSignalHandler(
 	process Process,
 ) (WaitFunc, error) {
 	if !process.Valid() {
-		return nil, errors.NewCode(ErrInvalidProcess)
+		return nil, ErrInvalidProcess
 	}
 
 	sCtx, stop := signal.NotifyContext(ctx, defaultSignals...)

--- a/pkg/process/signal_handler_test.go
+++ b/pkg/process/signal_handler_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,16 +41,9 @@ func TestUnit_AsyncStartWithSignalHandler_WhenProcessInvalid_ExpectError(t *test
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-
 			_, err := AsyncStartWithSignalHandler(context.Background(), testCase.process)
 
-			assert.True(
-				t,
-				errors.IsErrorWithCode(err, ErrInvalidProcess),
-				"Actual err: %v",
-				err,
-			)
-
+			assert.Equal(t, ErrInvalidProcess, err, "Actual err: %v", err)
 		})
 	}
 }

--- a/pkg/server/errors.go
+++ b/pkg/server/errors.go
@@ -3,6 +3,9 @@ package server
 import "github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 
 const (
-	UnsupportedProtocol errors.ErrorCode = 300
-	UnsupportedMethod   errors.ErrorCode = 301
+	errUnsupportedMethod errors.ErrorCode = 300
+)
+
+var (
+	ErrUnsupportedMethod = errors.FromCode(errUnsupportedMethod)
 )

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	om "github.com/Knoblauchpilze/backend-toolkit/pkg/middleware"
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/rest"
 	"github.com/labstack/echo/v5"
@@ -58,7 +57,7 @@ func (s *serverImpl) AddRoute(route rest.Route) error {
 	case http.MethodPatch:
 		s.router.PATCH(path, route.Handler(), middlewares...)
 	default:
-		return errors.NewCode(UnsupportedMethod)
+		return ErrUnsupportedMethod
 	}
 
 	s.echo.Logger.Debug("Registered route", slog.String("method", route.Method()), slog.String("path", path))

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/process"
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/rest"
 	"github.com/labstack/echo/v5"
@@ -32,12 +31,7 @@ func TestUnit_Server_WhenAddingUnSupportedRoutes_ExpectFailure(t *testing.T) {
 		t.Run(method, func(t *testing.T) {
 			sampleRoute := rest.NewRoute(method, "/", testHttpHandler)
 			err := s.AddRoute(sampleRoute)
-			assert.True(
-				t,
-				errors.IsErrorWithCode(err, UnsupportedMethod),
-				"Actual err: %v",
-				err,
-			)
+			assert.Equal(t, ErrUnsupportedMethod, err, "Actual err: %v", err)
 		})
 	}
 }
@@ -122,7 +116,7 @@ func TestUnit_Server_WhenHandlerPanics_ExpectErrorResponseEnvelope(t *testing.T)
 func TestUnit_Server_WhenHandlerReturnsError_ExpectErrorResponseEnvelope(t *testing.T) {
 	s := newTestServer(4004)
 	errorHandler := func(c *echo.Context) error {
-		return errors.NewCode(db.AlreadyCommitted)
+		return db.ErrAlreadyCommitted
 	}
 	route := rest.NewRoute(http.MethodGet, "/", errorHandler)
 	err := s.AddRoute(route)
@@ -139,7 +133,7 @@ func TestUnit_Server_WhenHandlerReturnsError_ExpectErrorResponseEnvelope(t *test
 	assert.Equal(t, http.StatusInternalServerError, response.StatusCode)
 	actual := unmarshalResponseAndAssertRequestId(t, response)
 	assert.Equal(t, "ERROR", actual.Status)
-	assert.Equal(t, `{"message":"An unexpected error occurred. Code: 102"}`, string(actual.Details))
+	assert.Equal(t, `{"message":"an unexpected error occurred. Code: 102"}`, string(actual.Details))
 }
 
 type responseEnvelope struct {


### PR DESCRIPTION
# Work

The `ErrorWithCode` is currently an interface which only defines a single method, `Code`. TO make it easier to work with the database errors and particularly to be able to analyze which constraint caused an error (e.g. a unique constraint), it would be beneficial to have a dedicated type of errors that would contain information about the database issue.

This is currently not easily possible due to the error with code not being exposed to the outside world. In general it seems like this is not very idiomatic to have an interface for the error: especially one which does not embed the `error` interface.

To work around this, this PR changes the `ErrorWithCode` from being an interface to a real struct with exposed fields. This will help clearly separate a simple error from a database error in the future: they can be two different types which implement the `error` interface.

# Tests

The unit tests have been updated to reflect and use the new error struct.

# Future work

A new type should be added to represent the database errors.
